### PR TITLE
feat(blog): global-style 및 theme 설정 수정 #39

### DIFF
--- a/packages/blog/pages/_app.tsx
+++ b/packages/blog/pages/_app.tsx
@@ -7,8 +7,8 @@ import 'katex/dist/katex.min.css'
 const MyApp = ({ Component, pageProps }: AppProps) => {
   return (
     <>
-      <GlobalStyle />
       <ThemeProvider theme={theme}>
+        <GlobalStyle />
         <Component {...pageProps} />
       </ThemeProvider>
     </>

--- a/packages/blog/styles/glolbal-style.tsx
+++ b/packages/blog/styles/glolbal-style.tsx
@@ -54,13 +54,13 @@ const GlobalStyle = createGlobalStyle`
     padding: 0;
   }
   button:focus{
-    outline:none;
+    outline-color: ${({ theme }) => theme.color.main};
   }
   input:focus{
-	  outline: none;
+    outline-color: ${({ theme }) => theme.color.main};
   }
   a{
-	  outline: none;
+    outline-color: ${({ theme }) => theme.color.main};
 	  text-decoration: none;
   }
   a:visited, a:link {

--- a/packages/blog/styles/theme.ts
+++ b/packages/blog/styles/theme.ts
@@ -1,4 +1,4 @@
-import {} from 'styled-components'
+import { css } from 'styled-components'
 
 const color = {
   main: '#558FFF',
@@ -10,7 +10,7 @@ const color = {
   grey400: '#737373',
 } as const
 
-export const breakpoint = {
+const breakpoint = {
   sm: '640px',
   md: '768px',
   lg: '1024px',
@@ -20,6 +20,7 @@ export const breakpoint = {
 
 export const theme = {
   color,
+  breakpoint,
 }
 
 export type Theme = typeof theme


### PR DESCRIPTION
a11y 를 충족하기 위한 `outline: none` -> `outline-color: ${({ theme }) => theme.color.main}` 으로 변경
theme에 breakpoint 추가

> 미리보기
<img width="1199" alt="image" src="https://user-images.githubusercontent.com/48559454/164889483-0c21cee8-43a7-4829-bcd3-c2c4a02092b8.png">
